### PR TITLE
Feature/36 - New ticketmaster setCredentials

### DIFF
--- a/location/src/main/kotlin/io/rover/campaigns/location/domain/Geofence.kt
+++ b/location/src/main/kotlin/io/rover/campaigns/location/domain/Geofence.kt
@@ -19,11 +19,7 @@ data class Geofence(
     val identifier: String
         get() = "${center.latitude}:${center.longitude}:$radius"
 
-    companion object
-
-    data
-
-    class IdentiferComponents(
+    data class IdentiferComponents(
         val latitude: Double,
         val longitude: Double,
         val radius: Double
@@ -36,6 +32,8 @@ data class Geofence(
 
         constructor(identifier: String) : this(identifier.split(":"))
     }
+
+    companion object
 }
 
 fun Geofence.Center.asLocation(): Location {

--- a/ticketmaster/build.gradle
+++ b/ticketmaster/build.gradle
@@ -54,6 +54,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.12'
     // spek
+    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0"
     testImplementation "org.spekframework.spek2:spek-dsl-jvm:$spek_version"
     testImplementation "org.spekframework.spek2:spek-runner-junit5:$spek_version"
     androidTestImplementation 'com.android.support.test:runner:1.0.1'

--- a/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterAuthorizer.kt
+++ b/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterAuthorizer.kt
@@ -29,7 +29,10 @@ interface TicketmasterAuthorizer {
      * }
      * ```
     */
+    @Deprecated("Use setCredentials(id: String, email: String?, firstNameL String?) instead.")
     fun setCredentials(backendNameOrdinal: Int, memberId: String?)
+
+    fun setCredentials(id: String, email: String? = null, firstName: String? = null)
 
     /**
      * Clear the user's Ticketmaster credentials after a successful sign-out with the [Presence

--- a/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterAuthorizer.kt
+++ b/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterAuthorizer.kt
@@ -32,6 +32,35 @@ interface TicketmasterAuthorizer {
     @Deprecated("Use setCredentials(id: String, email: String?, firstName: String?) instead.")
     fun setCredentials(backendNameOrdinal: Int, memberId: String?)
 
+
+    /**
+     * Set the user's Ticketmaster credentials after a successful sign-in with the [Presence
+     * SDK](https://developer.ticketmaster.com/products-and-docs/sdks/presence-sdk/). Implement the
+     * `onMemberUpdated()` method in your `TMLoginListener` and call this
+     * method passing in values from the `memberInfo`. Only call this function if the value returned
+     * from (`memberInfo?.memberId`) is not null.
+
+     * @param id The value of the second parameter's (`memberInfo`) `id`
+     * property.
+     *
+     * @param email The value of the second parameter's (`memberInfo`) `email`
+     * property.
+     *
+     * @param firstName The value of the second parameter's (`memberInfo`) `firstName`
+     * property.
+     *
+     * Example:
+     *
+     * ```kotlin
+     * override fun onMemberUpdated(backendName: TMLoginApi.BackendName, memberInfo: TMLoginApi.MemberInfo?) {
+     *     Rover.sharedInstance.ticketmasterAuthorizer.setCredentials(
+     *         memberInfo?.memberId,
+     *         memberInfo?.email,
+     *         memberInfo?.firstName
+     *     )
+     * }
+     * ```
+     */
     fun setCredentials(id: String, email: String? = null, firstName: String? = null)
 
     /**

--- a/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterAuthorizer.kt
+++ b/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterAuthorizer.kt
@@ -29,7 +29,7 @@ interface TicketmasterAuthorizer {
      * }
      * ```
     */
-    @Deprecated("Use setCredentials(id: String, email: String?, firstNameL String?) instead.")
+    @Deprecated("Use setCredentials(id: String, email: String?, firstName: String?) instead.")
     fun setCredentials(backendNameOrdinal: Int, memberId: String?)
 
     fun setCredentials(id: String, email: String? = null, firstName: String? = null)

--- a/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
+++ b/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
@@ -32,6 +32,8 @@ class TicketmasterManager(
 
         private const val LEGACY_STORAGE_2X_SHARED_PREFERENCES =
             "io.rover.core.platform.localstorage.io.rover.ticketmaster.TicketmasterManager"
+
+        private const val TICKETMASTER_MAP_KEY = "ticketmaster"
     }
 
     override fun setCredentials(backendNameOrdinal: Int, memberId: String?) {
@@ -54,25 +56,26 @@ class TicketmasterManager(
         updateUserInfoWithMemberAttributes()
     }
 
+    @Suppress("UNCHECKED_CAST")
     private fun updateUserInfoWithMemberAttributes() {
         val localPropertiesMap = member?.getNonNullPropertiesMapWithoutId()
 
         userInfo.update {
-            if (it.containsKey("ticketmaster")) {
-                val tmAttributes = it.getValue("ticketmaster") as MutableMap<String, Any>
+            if (it.containsKey(TICKETMASTER_MAP_KEY)) {
+                val tmAttributes = it.getValue(TICKETMASTER_MAP_KEY) as MutableMap<String, Any>
                 localPropertiesMap?.forEach { (propertyName, propertyValue) ->
                     tmAttributes[propertyName] = propertyValue
                 }
-                it["ticketmaster"] = tmAttributes
+                it[TICKETMASTER_MAP_KEY] = tmAttributes
             } else {
-                if (localPropertiesMap?.isNotEmpty() == true) it["ticketmaster"] = localPropertiesMap
+                if (localPropertiesMap?.isNotEmpty() == true) it[TICKETMASTER_MAP_KEY] = localPropertiesMap
             }
         }
     }
 
     override fun clearCredentials() {
         member = null
-        userInfo.update { it.remove("ticketmaster") }
+        userInfo.update { it.remove(TICKETMASTER_MAP_KEY) }
     }
 
     override fun initialRequest(): SyncRequest? {

--- a/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
+++ b/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
@@ -30,7 +30,8 @@ class TicketmasterManager(
     companion object {
         private const val STORAGE_CONTEXT_IDENTIFIER = "ticketmaster"
 
-        private const val LEGACY_STORAGE_2X_SHARED_PREFERENCES = "io.rover.core.platform.localstorage.io.rover.ticketmaster.TicketmasterManager"
+        private const val LEGACY_STORAGE_2X_SHARED_PREFERENCES =
+            "io.rover.core.platform.localstorage.io.rover.ticketmaster.TicketmasterManager"
     }
 
     override fun setCredentials(backendNameOrdinal: Int, memberId: String?) {
@@ -39,6 +40,8 @@ class TicketmasterManager(
             email = null,
             firstName = null
         )
+
+        updateUserInfoWithMemberAttributes()
     }
 
     override fun setCredentials(id: String, email: String?, firstName: String?) {
@@ -48,16 +51,23 @@ class TicketmasterManager(
             firstName = firstName
         )
 
+        updateUserInfoWithMemberAttributes()
+    }
+
+    private fun updateUserInfoWithMemberAttributes() {
         val localPropertiesMap = member?.getNonNullPropertiesMap()
 
         userInfo.update {
             if (it.containsKey("ticketmaster")) {
                 val tmAttributes = it.getValue("ticketmaster") as MutableMap<String, Any>
-                localPropertiesMap?.forEach { (propertyName, propertyValue) -> tmAttributes[propertyName] = propertyValue }
+                localPropertiesMap?.forEach { (propertyName, propertyValue) ->
+                    tmAttributes[propertyName] = propertyValue
+                }
                 it["ticketmaster"] = tmAttributes
-        } else {
-            if(localPropertiesMap?.isNotEmpty() == true) it["ticketmaster"] = localPropertiesMap
-        } }
+            } else {
+                if (localPropertiesMap?.isNotEmpty() == true) it["ticketmaster"] = localPropertiesMap
+            }
+        }
     }
 
     override fun clearCredentials() {
@@ -82,14 +92,15 @@ class TicketmasterManager(
             }
         }
     }
-    
+
     override fun saveResponse(json: JSONObject): SyncResult {
         return try {
-            val profileAttributesFromNetwork = TicketmasterSyncResponseData.decodeJson(json.getJSONObject("data")).ticketmasterProfile.attributes
+            val profileAttributesFromNetwork =
+                TicketmasterSyncResponseData.decodeJson(json.getJSONObject("data")).ticketmasterProfile.attributes
             val localMemberProperties = member?.getNonNullPropertiesMap()
             val mutableMapFromNetwork = profileAttributesFromNetwork?.toMutableMap()
 
-            localMemberProperties?.forEach {(key, value) ->
+            localMemberProperties?.forEach { (key, value) ->
                 mutableMapFromNetwork?.put(key, value)
             }
 
@@ -187,7 +198,11 @@ fun TicketmasterManager.Member.Companion.decodeJson(json: JSONObject): Ticketmas
 
 fun TicketmasterManager.Member.encodeJson(): JSONObject {
     return JSONObject().apply {
-        listOf(TicketmasterManager.Member::id, TicketmasterManager.Member::email, TicketmasterManager.Member::firstName).forEach {
+        listOf(
+            TicketmasterManager.Member::id,
+            TicketmasterManager.Member::email,
+            TicketmasterManager.Member::firstName
+        ).forEach {
             putProp(this@encodeJson, it)
         }
     }

--- a/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
+++ b/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
@@ -51,8 +51,8 @@ class TicketmasterManager(
         val localPropertiesMap = member?.getNonNullPropertiesMap()
 
         userInfo.update {
-            val tmAttributes = it.getValue("ticketmaster") as MutableMap<String, Any>
             if (it.containsKey("ticketmaster")) {
+                val tmAttributes = it.getValue("ticketmaster") as MutableMap<String, Any>
                 localPropertiesMap?.forEach { (propertyName, propertyValue) -> tmAttributes[propertyName] = propertyValue }
                 it["ticketmaster"] = tmAttributes
         } else {
@@ -82,11 +82,7 @@ class TicketmasterManager(
             }
         }
     }
-
-    private fun <K, V> MutableMap<K, V>.putIfNotPresent(keyToPut: K, valueToPut: V) {
-        if (!this.containsKey(keyToPut)) this[keyToPut] = valueToPut
-    }
-
+    
     override fun saveResponse(json: JSONObject): SyncResult {
         return try {
             val profileAttributesFromNetwork = TicketmasterSyncResponseData.decodeJson(json.getJSONObject("data")).ticketmasterProfile.attributes

--- a/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
+++ b/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
@@ -36,7 +36,7 @@ class TicketmasterManager(
 
     override fun setCredentials(backendNameOrdinal: Int, memberId: String?) {
         member = Member(
-            id = memberId,
+            ticketmasterID = memberId,
             email = null,
             firstName = null
         )
@@ -46,7 +46,7 @@ class TicketmasterManager(
 
     override fun setCredentials(id: String, email: String?, firstName: String?) {
         member = Member(
-            id = id,
+            ticketmasterID = id,
             email = email,
             firstName = firstName
         )
@@ -79,7 +79,7 @@ class TicketmasterManager(
         return member.whenNotNull { member ->
 
             val params = listOfNotNull(
-                member.id.whenNotNull { Pair(TICKETMASTER_ID_KEY, it) }
+                member.ticketmasterID.whenNotNull { Pair(TICKETMASTER_ID_KEY, it) }
             )
 
             if (params.isEmpty()) {
@@ -158,7 +158,7 @@ class TicketmasterManager(
     }
 
     data class Member(
-        val id: String?,
+        val ticketmasterID: String?,
         val email: String?,
         val firstName: String?
     ) {
@@ -167,7 +167,7 @@ class TicketmasterManager(
         fun getNonNullPropertiesMap(): Map<String, String> {
             val propertiesMap = mutableMapOf<String, String>()
 
-            id.whenNotNull { propertiesMap.put(TicketmasterManager.Member::id.name, it) }
+            ticketmasterID.whenNotNull { propertiesMap.put(TicketmasterManager.Member::ticketmasterID.name, it) }
             email.whenNotNull { propertiesMap.put(TicketmasterManager.Member::email.name, it) }
             firstName.whenNotNull { propertiesMap.put(TicketmasterManager.Member::firstName.name, it) }
             return propertiesMap
@@ -190,7 +190,7 @@ val SyncQuery.Companion.ticketmaster
 
 fun TicketmasterManager.Member.Companion.decodeJson(json: JSONObject): TicketmasterManager.Member {
     return TicketmasterManager.Member(
-        id = json.safeOptString(TicketmasterManager.Member::id.name),
+        ticketmasterID = json.safeOptString(TicketmasterManager.Member::ticketmasterID.name),
         email = json.safeOptString(TicketmasterManager.Member::email.name),
         firstName = json.safeOptString(TicketmasterManager.Member::firstName.name)
     )
@@ -199,7 +199,7 @@ fun TicketmasterManager.Member.Companion.decodeJson(json: JSONObject): Ticketmas
 fun TicketmasterManager.Member.encodeJson(): JSONObject {
     return JSONObject().apply {
         listOf(
-            TicketmasterManager.Member::id,
+            TicketmasterManager.Member::ticketmasterID,
             TicketmasterManager.Member::email,
             TicketmasterManager.Member::firstName
         ).forEach {

--- a/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
+++ b/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
@@ -196,8 +196,8 @@ fun TicketmasterManager.Member.Companion.decodeJson(json: JSONObject): Ticketmas
     )
 }
 
-fun TicketmasterManager.Member.encodeJson(): JSONObject {
-    return JSONObject().apply {
+fun TicketmasterManager.Member.encodeJson(jsonObject: JSONObject = JSONObject()): JSONObject {
+    return jsonObject.apply {
         listOf(
             TicketmasterManager.Member::ticketmasterID,
             TicketmasterManager.Member::email,

--- a/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
+++ b/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
@@ -55,7 +55,7 @@ class TicketmasterManager(
     }
 
     private fun updateUserInfoWithMemberAttributes() {
-        val localPropertiesMap = member?.getNonNullPropertiesMap()
+        val localPropertiesMap = member?.getNonNullPropertiesMapWithoutId()
 
         userInfo.update {
             if (it.containsKey("ticketmaster")) {
@@ -97,7 +97,7 @@ class TicketmasterManager(
         return try {
             val profileAttributesFromNetwork =
                 TicketmasterSyncResponseData.decodeJson(json.getJSONObject("data")).ticketmasterProfile.attributes
-            val localMemberProperties = member?.getNonNullPropertiesMap()
+            val localMemberProperties = member?.getNonNullPropertiesMapWithoutId()
             val mutableMapFromNetwork = profileAttributesFromNetwork?.toMutableMap()
 
             localMemberProperties?.forEach { (key, value) ->
@@ -164,10 +164,8 @@ class TicketmasterManager(
     ) {
         companion object
 
-        fun getNonNullPropertiesMap(): Map<String, String> {
+        fun getNonNullPropertiesMapWithoutId(): Map<String, String> {
             val propertiesMap = mutableMapOf<String, String>()
-
-            ticketmasterID.whenNotNull { propertiesMap.put(TicketmasterManager.Member::ticketmasterID.name, it) }
             email.whenNotNull { propertiesMap.put(TicketmasterManager.Member::email.name, it) }
             firstName.whenNotNull { propertiesMap.put(TicketmasterManager.Member::firstName.name, it) }
             return propertiesMap

--- a/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
+++ b/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
@@ -191,7 +191,9 @@ val SyncQuery.Companion.ticketmaster
 
 fun TicketmasterManager.Member.Companion.decodeJson(json: JSONObject): TicketmasterManager.Member {
     return TicketmasterManager.Member(
-        ticketmasterID = json.safeOptString(TicketmasterManager.Member::ticketmasterID.name),
+        ticketmasterID = json.safeOptString(TicketmasterManager.Member::ticketmasterID.name)
+            ?: json.safeOptString("hostID")
+            ?: json.safeOptString("teamID"),
         email = json.safeOptString(TicketmasterManager.Member::email.name),
         firstName = json.safeOptString(TicketmasterManager.Member::firstName.name)
     )

--- a/ticketmaster/src/test/java/io/rover/ticketmaster/TicketMasterManagerTest.kt
+++ b/ticketmaster/src/test/java/io/rover/ticketmaster/TicketMasterManagerTest.kt
@@ -1,7 +1,11 @@
 package io.rover.ticketmaster
 
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import io.rover.campaigns.ticketmaster.TicketmasterManager.Member
+import io.rover.campaigns.ticketmaster.encodeJson
 import junit.framework.Assert.assertEquals
+import org.json.JSONObject
 import org.spekframework.spek2.Spek
 
 private const val ID = "id"
@@ -10,14 +14,14 @@ private const val FIRST_NAME = "example first name"
 
 object TicketMasterManagerTest: Spek({
     group("tmManagerMember") {
-        test("getNonNullPropertiesMap ignores null properties") {
+        test("getNonNullPropertiesMap() ignores null properties") {
             val member = Member(ID, null, null)
             val expectedMap = mapOf(member::ticketmasterID.name to ID)
 
             assertEquals(expectedMap, member.getNonNullPropertiesMap())
         }
 
-        test("getNonNullPropertiesMap returns all non null properties") {
+        test("getNonNullPropertiesMap() returns all non null properties") {
             val member = Member(ID, EMAIL, FIRST_NAME)
             val expectedMap = mapOf(
                 member::ticketmasterID.name to ID,
@@ -28,11 +32,22 @@ object TicketMasterManagerTest: Spek({
             assertEquals(expectedMap, member.getNonNullPropertiesMap())
         }
 
-        test("getNonNullPropertiesMap returns empty with all null properties") {
+        test("getNonNullPropertiesMap() returns empty with all null properties") {
             val member = Member(null, null, null)
             val expectedMap = mapOf<String, String>()
 
             assertEquals(expectedMap, member.getNonNullPropertiesMap())
+        }
+
+        test("encodeJson() adds properties to JSONObject") {
+            val member = Member(ID, EMAIL, FIRST_NAME)
+            val mockJsonObject = mock<JSONObject>()
+
+            member.encodeJson(mockJsonObject)
+
+            verify(mockJsonObject).put(member::ticketmasterID.name, ID)
+            verify(mockJsonObject).put(member::firstName.name, FIRST_NAME)
+            verify(mockJsonObject).put(member::email.name, EMAIL)
         }
     }
 })

--- a/ticketmaster/src/test/java/io/rover/ticketmaster/TicketMasterManagerTest.kt
+++ b/ticketmaster/src/test/java/io/rover/ticketmaster/TicketMasterManagerTest.kt
@@ -1,0 +1,38 @@
+package io.rover.ticketmaster
+
+import io.rover.campaigns.ticketmaster.TicketmasterManager.Member
+import junit.framework.Assert.assertEquals
+import org.spekframework.spek2.Spek
+
+private const val ID = "id"
+private const val EMAIL = "example email"
+private const val FIRST_NAME = "example first name"
+
+object TicketMasterManagerTest: Spek({
+    group("tmManagerMember") {
+        test("getNonNullPropertiesMap ignores null properties") {
+            val member = Member(ID, null, null)
+            val expectedMap = mapOf(member::ticketmasterID.name to ID)
+
+            assertEquals(expectedMap, member.getNonNullPropertiesMap())
+        }
+
+        test("getNonNullPropertiesMap returns all non null properties") {
+            val member = Member(ID, EMAIL, FIRST_NAME)
+            val expectedMap = mapOf(
+                member::ticketmasterID.name to ID,
+                member::email.name to EMAIL,
+                member::firstName.name to FIRST_NAME
+            )
+
+            assertEquals(expectedMap, member.getNonNullPropertiesMap())
+        }
+
+        test("getNonNullPropertiesMap returns empty with all null properties") {
+            val member = Member(null, null, null)
+            val expectedMap = mapOf<String, String>()
+
+            assertEquals(expectedMap, member.getNonNullPropertiesMap())
+        }
+    }
+})

--- a/ticketmaster/src/test/java/io/rover/ticketmaster/TicketMasterManagerTest.kt
+++ b/ticketmaster/src/test/java/io/rover/ticketmaster/TicketMasterManagerTest.kt
@@ -14,29 +14,21 @@ private const val FIRST_NAME = "example first name"
 
 object TicketMasterManagerTest: Spek({
     group("tmManagerMember") {
-        test("getNonNullPropertiesMap() ignores null properties") {
-            val member = Member(ID, null, null)
-            val expectedMap = mapOf(member::ticketmasterID.name to ID)
-
-            assertEquals(expectedMap, member.getNonNullPropertiesMap())
-        }
-
-        test("getNonNullPropertiesMap() returns all non null properties") {
+        test("getNonNullPropertiesMapWithoutID() returns all non null except ID properties") {
             val member = Member(ID, EMAIL, FIRST_NAME)
             val expectedMap = mapOf(
-                member::ticketmasterID.name to ID,
                 member::email.name to EMAIL,
                 member::firstName.name to FIRST_NAME
             )
 
-            assertEquals(expectedMap, member.getNonNullPropertiesMap())
+            assertEquals(expectedMap, member.getNonNullPropertiesMapWithoutId())
         }
 
-        test("getNonNullPropertiesMap() returns empty with all null properties") {
+        test("getNonNullPropertiesMapWithoutID() returns empty with all null properties") {
             val member = Member(null, null, null)
             val expectedMap = mapOf<String, String>()
 
-            assertEquals(expectedMap, member.getNonNullPropertiesMap())
+            assertEquals(expectedMap, member.getNonNullPropertiesMapWithoutId())
         }
 
         test("encodeJson() adds properties to JSONObject") {

--- a/ticketmaster/src/test/java/io/rover/ticketmaster/TicketMasterManagerTest.kt
+++ b/ticketmaster/src/test/java/io/rover/ticketmaster/TicketMasterManagerTest.kt
@@ -2,7 +2,10 @@ package io.rover.ticketmaster
 
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import io.rover.campaigns.core.data.graphql.safeOptString
 import io.rover.campaigns.ticketmaster.TicketmasterManager.Member
+import io.rover.campaigns.ticketmaster.decodeJson
 import io.rover.campaigns.ticketmaster.encodeJson
 import junit.framework.Assert.assertEquals
 import org.json.JSONObject
@@ -40,6 +43,43 @@ object TicketMasterManagerTest: Spek({
             verify(mockJsonObject).put(member::ticketmasterID.name, ID)
             verify(mockJsonObject).put(member::firstName.name, FIRST_NAME)
             verify(mockJsonObject).put(member::email.name, EMAIL)
+        }
+
+        test("decodeJson() creates Member with all properties successfully") {
+            val expectedMember = Member(ID, EMAIL, FIRST_NAME)
+            val mockJsonObject = mock<JSONObject>()
+
+            whenever(mockJsonObject.safeOptString("ticketmasterID")).thenReturn(ID)
+            whenever(mockJsonObject.safeOptString("email")).thenReturn(EMAIL)
+            whenever(mockJsonObject.safeOptString("firstName")).thenReturn(FIRST_NAME)
+
+            assertEquals(expectedMember, Member.decodeJson(mockJsonObject))
+        }
+
+        test("decodeJson() creates Member from legacy hostID") {
+            val expectedMember = Member(ID, null, null)
+            val mockJsonObject = mock<JSONObject>()
+
+            whenever(mockJsonObject.safeOptString("hostID")).thenReturn(ID)
+
+            assertEquals(expectedMember, Member.decodeJson(mockJsonObject))
+        }
+
+        test("decodeJson() creates Member from legacy teamID") {
+            val expectedMember = Member(ID, null, null)
+            val mockJsonObject = mock<JSONObject>()
+
+            whenever(mockJsonObject.safeOptString("teamID")).thenReturn(ID)
+
+            assertEquals(expectedMember, Member.decodeJson(mockJsonObject))
+        }
+
+        test("decodeJson() creates Member with null properties") {
+            val expectedMember = Member(null, null, null)
+
+            val mockJsonObject = mock<JSONObject>()
+
+            assertEquals(expectedMember, Member.decodeJson(mockJsonObject))
         }
     }
 })


### PR DESCRIPTION
## Description
- Deprecate old `setCredentials`  in `TicketmasterAuthorizer`
- Add new `setCredentials` method with signature `setCredentials(id: String, email: String? = null, firstName: String? = null)`
- Update user info immediately after calling `setCredentials`
- in `saveResponse`, if not null, clobber `firstName` and `email` with the locally persisted values and update user info with the new map consisting of the properties from the network and the local properties.
- Add a few test for code that doesn't require much modification in order to test