### PR TITLE
Hotfix/3.2.1 - PR for review only

### DIFF
--- a/core/src/main/kotlin/io/rover/campaigns/core/CoreAssembler.kt
+++ b/core/src/main/kotlin/io/rover/campaigns/core/CoreAssembler.kt
@@ -155,8 +155,11 @@ class CoreAssembler @JvmOverloads constructor(
             application
         }
 
-        container.register(Scope.Singleton, Intent::class.java, "openApp") { _ ->
-            openAppIntent ?: application.packageManager.getLaunchIntentForPackage(application.packageName)
+
+        if (openAppIntent != null || application.packageManager.getLaunchIntentForPackage(application.packageName) != null) {
+            container.register(Scope.Singleton, Intent::class.java, "openApp") { _ ->
+                openAppIntent ?: application.packageManager.getLaunchIntentForPackage(application.packageName)
+            }
         }
 
         container.register(Scope.Singleton, UrlSchemes::class.java) { _ ->

--- a/core/src/main/kotlin/io/rover/campaigns/core/CoreAssembler.kt
+++ b/core/src/main/kotlin/io/rover/campaigns/core/CoreAssembler.kt
@@ -156,8 +156,7 @@ class CoreAssembler @JvmOverloads constructor(
         }
 
         container.register(Scope.Singleton, Intent::class.java, "openApp") { _ ->
-            openAppIntent ?: application
-                .packageManager.getLaunchIntentForPackage(application.packageName)
+            openAppIntent ?: application.packageManager.getLaunchIntentForPackage(application.packageName)
         }
 
         container.register(Scope.Singleton, UrlSchemes::class.java) { _ ->
@@ -360,7 +359,7 @@ class CoreAssembler @JvmOverloads constructor(
             Router::class.java
         ) { resolver ->
             RouterService(
-                resolver.resolveSingletonOrFail(Intent::class.java, "openApp")
+                resolver.resolve(Intent::class.java, "openApp")
             )
         }
 
@@ -440,7 +439,7 @@ class CoreAssembler @JvmOverloads constructor(
 
         resolver.resolveSingletonOrFail(Router::class.java).apply {
             registerRoute(
-                OpenAppRoute(resolver.resolveSingletonOrFail(Intent::class.java, "openApp"))
+                OpenAppRoute(resolver.resolve(Intent::class.java, "openApp"))
             )
         }
 

--- a/core/src/main/kotlin/io/rover/campaigns/core/events/EventQueueService.kt
+++ b/core/src/main/kotlin/io/rover/campaigns/core/events/EventQueueService.kt
@@ -59,7 +59,6 @@ class EventQueueService(
     }
 
     override fun trackEvent(event: Event, namespace: String?) {
-        log.v("Tracking event: $event")
         captureContext()
         enqueueEvent(event, namespace)
         eventSubject.onNext(event)

--- a/core/src/main/kotlin/io/rover/campaigns/core/events/EventQueueService.kt
+++ b/core/src/main/kotlin/io/rover/campaigns/core/events/EventQueueService.kt
@@ -23,6 +23,7 @@ import io.rover.campaigns.core.streams.observeOn
 import io.rover.campaigns.core.streams.share
 import org.json.JSONArray
 import org.reactivestreams.Publisher
+import java.lang.AssertionError
 import java.util.Deque
 import java.util.LinkedList
 import java.util.concurrent.Executors
@@ -59,6 +60,14 @@ class EventQueueService(
     }
 
     override fun trackEvent(event: Event, namespace: String?) {
+        try {
+            log.v("Tracking event: $event")
+        } catch (e: AssertionError) {
+            // Workaround for a bug in Android that can cause crashes on Android 8.0 and 8.1 when
+            // calling toString() on a java.util.Date
+            log.w("Logging tracking event failed: $e")
+        }
+
         captureContext()
         enqueueEvent(event, namespace)
         eventSubject.onNext(event)

--- a/core/src/main/kotlin/io/rover/campaigns/core/routing/Interfaces.kt
+++ b/core/src/main/kotlin/io/rover/campaigns/core/routing/Interfaces.kt
@@ -14,7 +14,7 @@ interface Router {
      * something within the Rover SDK, and that any URIs that fail to match any registered routes
      * should be deferred to Android itself.
      */
-    fun route(uri: URI?, inbound: Boolean): Intent
+    fun route(uri: URI?, inbound: Boolean): Intent?
 
     /**
      * Register the given route.  Should typically be called in [Assembler.afterAssembly]

--- a/core/src/main/kotlin/io/rover/campaigns/core/routing/RouterService.kt
+++ b/core/src/main/kotlin/io/rover/campaigns/core/routing/RouterService.kt
@@ -6,7 +6,7 @@ import io.rover.campaigns.core.logging.log
 import java.net.URI
 
 class RouterService(
-    private val openAppIntent: Intent
+    private val openAppIntent: Intent?
 ) : Router {
     private val registeredRoutes: MutableSet<Route> = mutableSetOf()
 
@@ -22,10 +22,8 @@ class RouterService(
 
         val handledByRover = mappedUris.firstOrNull()
 
-        return handledByRover ?: if (inbound || uri == null) {
-            openAppIntent.apply {
-                log.w("No Route matched `$uri`, just opening the app.")
-            }
+        return handledByRover ?: if (inbound || uri == null && openAppIntent != null) {
+            openAppIntent!!.apply { log.w("No Route matched `$uri`, just opening the app.") }
         } else {
             Intent(
                 Intent.ACTION_VIEW,

--- a/core/src/main/kotlin/io/rover/campaigns/core/routing/TransientLinkLaunchActivity.kt
+++ b/core/src/main/kotlin/io/rover/campaigns/core/routing/TransientLinkLaunchActivity.kt
@@ -30,16 +30,11 @@ open class TransientLinkLaunchActivity : AppCompatActivity() {
 
         log.v("Transient link launch activity running for received URI: '${intent.data}'")
 
-        val intentStack = linkOpen.localIntentForReceived(
-                uri
-        )
+        val intentStack = linkOpen.localIntentForReceived(uri)
 
         log.v("Launching stack ${intentStack.size} deep: ${intentStack.joinToString("\n") { it.toString() }}")
 
-        ContextCompat.startActivities(
-                this,
-                intentStack.toTypedArray()
-        )
+        if (intentStack.isNotEmpty()) ContextCompat.startActivities(this, intentStack.toTypedArray())
         finish()
     }
 }

--- a/core/src/main/kotlin/io/rover/campaigns/core/routing/routes/OpenAppRoute.kt
+++ b/core/src/main/kotlin/io/rover/campaigns/core/routing/routes/OpenAppRoute.kt
@@ -5,7 +5,7 @@ import io.rover.campaigns.core.routing.Route
 import java.net.URI
 
 class OpenAppRoute(
-    private val openAppIntent: Intent
+    private val openAppIntent: Intent?
 ) : Route {
     override fun resolveUri(uri: URI?): Intent? {
         // a null URI means merely open app, which means it should map to this route.

--- a/core/src/main/kotlin/io/rover/campaigns/core/ui/LinkOpen.kt
+++ b/core/src/main/kotlin/io/rover/campaigns/core/ui/LinkOpen.kt
@@ -9,6 +9,6 @@ class LinkOpen(
     private val router: Router
 ) : LinkOpenInterface {
     override fun localIntentForReceived(receivedUri: URI): List<Intent> {
-        return listOf(router.route(receivedUri, true))
+        return listOfNotNull(router.route(receivedUri, true))
     }
 }

--- a/notifications/src/main/kotlin/io/rover/campaigns/notifications/Interfaces.kt
+++ b/notifications/src/main/kotlin/io/rover/campaigns/notifications/Interfaces.kt
@@ -76,7 +76,7 @@ interface NotificationOpenInterface {
      * Return an intent for opening a notification from the Android notification drawer. This is
      * called by the transient notification launch activity to replace itself with a new stack.
      */
-    fun intentForOpeningNotificationFromJson(notificationJson: String): Intent
+    fun intentForOpeningNotificationFromJson(notificationJson: String): Intent?
 
     /**
      * Return an intent for directly opening the notification within the app.

--- a/notifications/src/main/kotlin/io/rover/campaigns/notifications/NotificationOpen.kt
+++ b/notifications/src/main/kotlin/io/rover/campaigns/notifications/NotificationOpen.kt
@@ -22,7 +22,7 @@ open class NotificationOpen(
     private val dateFormatting: DateFormattingInterface,
     private val eventsService: EventQueueServiceInterface,
     private val router: Router,
-    private val openAppIntent: Intent,
+    private val openAppIntent: Intent?,
     private val embeddedWebBrowserDisplay: EmbeddedWebBrowserDisplayInterface
 ) : NotificationOpenInterface {
     override fun pendingIntentForAndroidNotification(notification: Notification): PendingIntent {

--- a/notifications/src/main/kotlin/io/rover/campaigns/notifications/NotificationOpen.kt
+++ b/notifications/src/main/kotlin/io/rover/campaigns/notifications/NotificationOpen.kt
@@ -32,20 +32,17 @@ open class NotificationOpen(
         )
     }
 
-    private fun intentForNotification(notification: Notification): Intent {
+    private fun intentForNotification(notification: Notification): Intent? {
         return when (notification.tapBehavior) {
             is Notification.TapBehavior.OpenApp -> openAppIntent
-            is Notification.TapBehavior.OpenUri -> router.route(
-                notification.tapBehavior.uri,
-                false
-            )
+            is Notification.TapBehavior.OpenUri -> router.route(notification.tapBehavior.uri, false)
             is Notification.TapBehavior.PresentWebsite -> embeddedWebBrowserDisplay.intentForViewingWebsiteViaEmbeddedBrowser(
                 notification.tapBehavior.url.toString()
             )
         }
     }
 
-    override fun intentForOpeningNotificationFromJson(notificationJson: String): Intent {
+    override fun intentForOpeningNotificationFromJson(notificationJson: String): Intent? {
         // side-effect: issue open event.
         val notification = Notification.decodeJson(JSONObject(notificationJson), dateFormatting)
 

--- a/notifications/src/main/kotlin/io/rover/campaigns/notifications/NotificationsAssembler.kt
+++ b/notifications/src/main/kotlin/io/rover/campaigns/notifications/NotificationsAssembler.kt
@@ -236,7 +236,7 @@ class NotificationsAssembler @JvmOverloads constructor(
                 resolver.resolveSingletonOrFail(DateFormattingInterface::class.java),
                 resolver.resolveSingletonOrFail(EventQueueServiceInterface::class.java),
                 resolver.resolveSingletonOrFail(Router::class.java),
-                resolver.resolveSingletonOrFail(Intent::class.java, "openApp"),
+                resolver.resolve(Intent::class.java, "openApp"),
                 resolver.resolveSingletonOrFail(EmbeddedWebBrowserDisplayInterface::class.java)
             )
         }

--- a/notifications/src/main/kotlin/io/rover/campaigns/notifications/TransientNotificationLaunchActivity.kt
+++ b/notifications/src/main/kotlin/io/rover/campaigns/notifications/TransientNotificationLaunchActivity.kt
@@ -67,37 +67,36 @@ class TransientNotificationLaunchActivity : AppCompatActivity() {
         // is the whole reason for this activity existing.
 
         val intent = notificationOpen.intentForOpeningNotificationFromJson(notificationJson)
-
-        intent?.let {
-            if (intent.resolveActivityInfo(this.packageManager, PackageManager.GET_SHARED_LIBRARY_FILES) == null) {
-                log.e(
-                    "No activity could be found to handle the Intent needed to start the notification.\n" +
-                        "This could be because the deep link scheme slug you set on NotificationsAssembler does not match what is set in your Rover account, or that an Activity is missing from your manifest.\n\n" +
-                        "Intent was: $intent"
-                )
-                finish()
-                return
-            }
-
-            try {
-                val notification = Notification.decodeJson(
-                    JSONObject(notificationJson),
-                    dateFormatting
-                )
-                notificationsRepository?.markRead(notification)
-            } catch (e: JSONException) {
-                log.w("Badly formed notification, could not mark it as read.")
-            }
-
-            influenceTracker.notificationOpenedDirectly()
-
-            ContextCompat.startActivity(
-                this,
-                intent,
-                null
-            )
-        }
         
+        if (intent?.resolveActivityInfo(this.packageManager, PackageManager.GET_SHARED_LIBRARY_FILES) == null) {
+            log.e(
+                "No activity could be found to handle the Intent needed to start the notification.\n" +
+                    "This could be because the deep link scheme slug you set on NotificationsAssembler does not match what is set in your Rover account, or that an Activity is missing from your manifest.\n\n" +
+                    "Intent was: $intent"
+            )
+            finish()
+            return
+        }
+
+        try {
+            val notification = Notification.decodeJson(
+                JSONObject(notificationJson),
+                dateFormatting
+            )
+            notificationsRepository?.markRead(notification)
+        } catch (e: JSONException) {
+            log.w("Badly formed notification, could not mark it as read.")
+        }
+
+        influenceTracker.notificationOpenedDirectly()
+
+        ContextCompat.startActivity(
+            this,
+            intent,
+            null
+        )
+
+
         finish()
     }
 
@@ -108,7 +107,8 @@ class TransientNotificationLaunchActivity : AppCompatActivity() {
         ): PendingIntent {
 
             val notificationJson = notification.encodeJson(
-                (RoverCampaigns.shared ?: throw RuntimeException("Cannot generate Rover Campaigns intent when Rover Campaigns is not initialized."))
+                (RoverCampaigns.shared
+                    ?: throw RuntimeException("Cannot generate Rover Campaigns intent when Rover Campaigns is not initialized."))
                     .resolveSingletonOrFail(DateFormattingInterface::class.java)
             )
 


### PR DESCRIPTION
## Description
### Problem 1
Need to make `openAppIntent` nullable in the `RouterService` and `OpenAppRoute()` the reasoning for this is that `getLaunchIntentForPackage` is nullable so we can't guarantee that `openAppIntent` is not null.

### Solution 1
This change means that a few interfaces now need to return nullable intents. In `TransientNotificationLaunchActivity` and `TransientLinkLaunchActivity`, i've defensively accommodated for the fact that the Intent might be null or in the case of `TransientLinkLaunchActivity`, the list of `Intent` may be empty.

### Problem 2
An issue that causes an `AssertionError` when calling `.toString()`  on a java.util.Date for some devices running 8+. This seems to occur with our `Event` data class as it has a parameter of type `Date`.

### Solution 2
Remove offending line in `EventQueueService` that is only used for logging