### PR TITLE
Feature/43 - Support for Q sdk

### DIFF
--- a/location/src/main/kotlin/io/rover/campaigns/location/GoogleBeaconTrackerService.kt
+++ b/location/src/main/kotlin/io/rover/campaigns/location/GoogleBeaconTrackerService.kt
@@ -130,7 +130,7 @@ class GoogleBeaconTrackerService(
 
     companion object {
         private const val BACKGROUND_LOCATION_PERMISSION_CODE = "android.permission.ACCESS_BACKGROUND_LOCATION"
-        private const val Q_SDK_BUILD_VERSION = 29
+        private const val Q_VERSION_CODE = 29
     }
 
     init {
@@ -147,7 +147,7 @@ class GoogleBeaconTrackerService(
             }
         }.observeOn(mainScheduler).subscribe { beaconUuids ->
             if (ContextCompat.checkSelfPermission(applicationContext, BACKGROUND_LOCATION_PERMISSION_CODE) == PackageManager.PERMISSION_GRANTED
-                || applicationContext.applicationInfo?.targetSdkVersion ?: Build.VERSION.SDK_INT < Q_SDK_BUILD_VERSION) {
+                || applicationContext.applicationInfo?.targetSdkVersion ?: Build.VERSION.SDK_INT < Q_VERSION_CODE) {
                 log.d("background permission build version true, build version: ${Build.VERSION.SDK_INT}")
                 startMonitoringBeacons(beaconUuids)
             }


### PR DESCRIPTION
## Description

![Screen Shot 2019-08-26 at 2.02.03 PM.png](https://codetreeusercontent.s3.amazonaws.com/uploads/e12f7292-192b-43ca-8c65-8b8259158eb1/Screen+Shot+2019-08-26+at+2.02.03+PM.png)

Here's the Q checklist. We don't have to worry about Scoped storage, background activity starts or non-resettable hardware identifiers as we don't use/interact with any of these. 

## Background Location Service

The breakdown for the location permissions for our `BackgroundLocationService` is as follows. For app that don't target Q everything works the same as before, If running on a Q device and the user grants fine or coarse location permissions then background location permissions is automatically granted also. So no changes needed for this.
If an app targets Q then the updates will behave according to user preference. If they grant background update access our updates will trigger in the background, if they only grant foreground access our updates will only trigger in the foreground. 

### Solution
We should probably instruct customers to specifically request background permissions (as well as fine location permissions) so that users can allow background updates if they wish. But as far as we're concerned we don't have to make any changes in order to comply with the user's wishes and also to adapt to Q

Requesting fine and background
![Screen Shot 2019-08-26 at 12.33.59 PM.png](https://codetreeusercontent.s3.amazonaws.com/uploads/e12f7292-192b-43ca-8c65-8b8259158eb1/Screen+Shot+2019-08-26+at+12.33.59+PM.png)

vs requesting just fine
![Screen Shot 2019-08-27 at 12.30.50 PM.png](https://codetreeusercontent.s3.amazonaws.com/uploads/e12f7292-192b-43ca-8c65-8b8259158eb1/Screen+Shot+2019-08-27+at+12.30.50+PM.png)

## Beacon Tracker Service

The issue we have with Q support appears to be just the gms Nearby messages api in our `BeaconTrackerService`. It seems when targeting Q that it requires both fine location and background location permissions otherwise the messages client subscription task will fail to subscribe and the user will receive notifications that the app is having trouble with google play services.
![Screen Shot 2019-08-27 at 12.44.45 PM.png](https://codetreeusercontent.s3.amazonaws.com/uploads/e12f7292-192b-43ca-8c65-8b8259158eb1/Screen+Shot+2019-08-27+at+12.44.45+PM.png)


### Solution
My solution to this problem would be to check the permission manually by string. This would ensure that before starting to monitor for beacons that the user has granted both required location permissions.

```
if (ContextCompat.checkSelfPermission(applicationContext, BACKGROUND_LOCATION_PERMISSION_CODE) == PackageManager.PERMISSION_GRANTED
                || applicationContext.applicationInfo?.targetSdkVersion ?: Build.VERSION.SDK_INT < Q_SDK_BUILD_VERSION) {
                log.d("background permission build version true, build version: ${Build.VERSION.SDK_INT}")
                startMonitoringBeacons(beaconUuids)
            }
```

If the user later revokes background or location permissions then the messageClient appears to stop gracefully and the user doesn't receive the error notification 

## Geofence Service

`GeofenceService` is similar to the `BackgroundLocationService` in that when not granted background permission, the user will not be aware of a problem, however when targeting Q without the background location permission granted the `geofencingClient` will be unable to configure Rover Geofence receiver, so geofences won't be monitored without this permission.

### Solution
I think the solution for this will be similar to the solution for the `BackgroundLocationService`, so do nothing but encourage customers to request background location permissions if they want to use geofencing.

### Related Issues
closes #43 