### PR TITLE
Feature/64 - support for opening experience with screenID for deep and universal links

### DIFF
--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation project(":notifications")
     implementation project(":debug")
     implementation project(":location")
-    implementation "io.rover:sdk:3.4.2"
+    implementation "io.rover:sdk:3.5.0"
     implementation project(":experiences")
 //    implementation project(":advertising")
     implementation project(":ticketmaster")

--- a/experiences/build.gradle
+++ b/experiences/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation project(':core')
-    api "io.rover:sdk:3.4.2"
+    api "io.rover:sdk:3.5.0"
 }
 
 configurations {


### PR DESCRIPTION
## Description 
Support for opening experience with screenID for deep and universal links

The following formats are supported: 

`https://sam.rover.io/KrwJxO?screenID=H1LDDkOUH`

`rv-sam://presentExperience?id=5d4da83f169d65001670a022&screenID=H1LDDkOUH`

## Do not merge until corresponding Rover branch release and updated rover dependencies

closes #64 