### PR TITLE
Bug/66 - Problem displaying snackbar in our NotificationCenterActivity

### DIFF
--- a/notifications/src/main/kotlin/io/rover/campaigns/notifications/ui/containers/NotificationCenterActivity.kt
+++ b/notifications/src/main/kotlin/io/rover/campaigns/notifications/ui/containers/NotificationCenterActivity.kt
@@ -12,7 +12,7 @@ class NotificationCenterActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         val listView = NotificationCenterListView(
-            applicationContext
+            this
         )
 
         listView.activity = this


### PR DESCRIPTION
## Description
Our notification center passes `applicationContext` to our `NotificationCenterListView`. This causes an xml inflation error when calling `Snackbar.make()` as the snackbar tries to retrieve theme attributes using the context of the view passed to it. It's expecting the context to be that of an `AppCompatActivity`

closes #66  