### PR TITLE
Bug - Prevent IllegalStateException crashing in InMemoryBitmapCacheStage

### DIFF
--- a/core/src/main/kotlin/io/rover/campaigns/core/assets/InMemoryBitmapCacheStage.kt
+++ b/core/src/main/kotlin/io/rover/campaigns/core/assets/InMemoryBitmapCacheStage.kt
@@ -57,6 +57,8 @@ class InMemoryBitmapCacheStage(
             PipelineStageResult.Successful(lruCache[input])
         } catch (e: UnableToCreateEntryException) {
             PipelineStageResult.Failed(e.reason)
+        } catch (e: IllegalStateException) {
+            PipelineStageResult.Failed(e)
         }
     }
 


### PR DESCRIPTION
## Description

Prevent IllegalStateException crashing in InMemoryBitmapCacheStage when thrown by the LruCache class and instead fault to the subsequent pipeline stage.  