### PR TITLE
Bug/49 - Prevent sync request from occurring with blank tm ID

### DIFF
--- a/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterAuthorizer.kt
+++ b/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterAuthorizer.kt
@@ -22,7 +22,7 @@ interface TicketmasterAuthorizer {
      *
      * ```kotlin
      * override fun onMemberUpdated(backendName: TMLoginApi.BackendName, memberInfo: TMLoginApi.MemberInfo?) {
-     *     Rover.sharedInstance.ticketmasterAuthorizer.setCredentials(
+     *     RoverCampaigns.shared.resolve(TicketmasterAuthorizer::class.java)?.setCredentials(
      *         backendName.ordinal,
      *         memberInfo?.memberId
      *     )
@@ -31,7 +31,6 @@ interface TicketmasterAuthorizer {
     */
     @Deprecated("Use setCredentials(id: String, email: String?, firstName: String?) instead.")
     fun setCredentials(backendNameOrdinal: Int, memberId: String?)
-
 
     /**
      * Set the user's Ticketmaster credentials after a successful sign-in with the [Presence
@@ -53,11 +52,13 @@ interface TicketmasterAuthorizer {
      *
      * ```kotlin
      * override fun onMemberUpdated(backendName: TMLoginApi.BackendName, memberInfo: TMLoginApi.MemberInfo?) {
-     *     Rover.sharedInstance.ticketmasterAuthorizer.setCredentials(
-     *         memberInfo?.memberId,
-     *         memberInfo?.email,
-     *         memberInfo?.firstName
-     *     )
+     *     memberInfo?.let {
+     *           RoverCampaigns.shared.resolve(TicketmasterAuthorizer::class.java)?.setCredentials(
+     *               it.memberId,
+     *               it.email,
+     *               it..firstName
+     *           )
+     *      }
      * }
      * ```
      */

--- a/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
+++ b/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
@@ -81,9 +81,11 @@ class TicketmasterManager(
     override fun initialRequest(): SyncRequest? {
         return member.whenNotNull { member ->
 
-            val params = listOfNotNull(
-                member.ticketmasterID.whenNotNull { Pair(TICKETMASTER_ID_KEY, it) }
-            )
+            val params = if (member.ticketmasterID.isNullOrEmpty()) {
+                emptyList()
+            } else {
+                listOf(Pair(TICKETMASTER_ID_KEY, member.ticketmasterID))
+            }
 
             if (params.isEmpty()) {
                 null

--- a/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
+++ b/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
@@ -37,30 +37,21 @@ class TicketmasterManager(
     }
 
     override fun setCredentials(backendNameOrdinal: Int, memberId: String?) {
-        if (memberId.isNullOrBlank()) {
-            clearCredentials()
-        } else {
-            member = Member(
-                ticketmasterID = memberId,
-                email = null,
-                firstName = null
-            )
-            updateUserInfoWithMemberAttributes()
-        }
+        member = Member(
+            ticketmasterID = memberId,
+            email = null,
+            firstName = null
+        )
+        updateUserInfoWithMemberAttributes()
     }
 
     override fun setCredentials(id: String, email: String?, firstName: String?) {
-        if (id.isBlank()) {
-            clearCredentials()
-        } else {
-            member = Member(
-                ticketmasterID = id,
-                email = email,
-                firstName = firstName
-            )
-
-            updateUserInfoWithMemberAttributes()
-        }
+        member = Member(
+            ticketmasterID = id,
+            email = email,
+            firstName = firstName
+        )
+        updateUserInfoWithMemberAttributes()
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
+++ b/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
@@ -50,15 +50,17 @@ class TicketmasterManager(
     }
 
     override fun setCredentials(id: String, email: String?, firstName: String?) {
-        if (id.isBlank()) clearCredentials()
+        if (id.isBlank()) {
+            clearCredentials()
+        } else {
+            member = Member(
+                ticketmasterID = id,
+                email = email,
+                firstName = firstName
+            )
 
-        member = Member(
-            ticketmasterID = id,
-            email = email,
-            firstName = firstName
-        )
-
-        updateUserInfoWithMemberAttributes()
+            updateUserInfoWithMemberAttributes()
+        }
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
+++ b/ticketmaster/src/main/kotlin/io/rover/campaigns/ticketmaster/TicketmasterManager.kt
@@ -37,16 +37,21 @@ class TicketmasterManager(
     }
 
     override fun setCredentials(backendNameOrdinal: Int, memberId: String?) {
-        member = Member(
-            ticketmasterID = memberId,
-            email = null,
-            firstName = null
-        )
-
-        updateUserInfoWithMemberAttributes()
+        if (memberId.isNullOrBlank()) {
+            clearCredentials()
+        } else {
+            member = Member(
+                ticketmasterID = memberId,
+                email = null,
+                firstName = null
+            )
+            updateUserInfoWithMemberAttributes()
+        }
     }
 
     override fun setCredentials(id: String, email: String?, firstName: String?) {
+        if (id.isBlank()) clearCredentials()
+
         member = Member(
             ticketmasterID = id,
             email = email,


### PR DESCRIPTION
### Description
Prevent TM sync request if member tm id is blank. Also clear the member credentials if tmID passed to tickemaster manager is blank. 

closes #49 