### PR TITLE
Editable Device Name Property

### DIFF
--- a/core/src/main/kotlin/io/rover/campaigns/core/events/contextproviders/DeviceIdentifierContextProvider.kt
+++ b/core/src/main/kotlin/io/rover/campaigns/core/events/contextproviders/DeviceIdentifierContextProvider.kt
@@ -8,7 +8,7 @@ class DeviceIdentifierContextProvider(
     deviceIdentification: DeviceIdentificationInterface
 ) : ContextProvider {
     private val identifier = deviceIdentification.installationIdentifier
-    private val deviceName = deviceIdentification.deviceName
+    private var deviceName = deviceIdentification.deviceName
 
     override fun captureContext(deviceContext: DeviceContext): DeviceContext {
         return deviceContext.copy(

--- a/core/src/main/kotlin/io/rover/campaigns/core/platform/DeviceIdentification.kt
+++ b/core/src/main/kotlin/io/rover/campaigns/core/platform/DeviceIdentification.kt
@@ -2,7 +2,6 @@ package io.rover.campaigns.core.platform
 
 import android.content.Context
 import android.os.Build
-import android.provider.Settings
 import io.rover.campaigns.core.logging.log
 import java.io.FileNotFoundException
 import java.util.UUID
@@ -16,7 +15,7 @@ interface DeviceIdentificationInterface {
     /**
      * User-set name for the device, if available.
      */
-    val deviceName: String?
+    var deviceName: String?
 }
 
 /**
@@ -27,14 +26,15 @@ class DeviceIdentification(
     localStorage: LocalStorage
 ) : DeviceIdentificationInterface {
     private val identifierKey = "identifier"
+    private val deviceNameKey = "deviceName"
     private val storage = localStorage.getKeyValueStorageFor(STORAGE_CONTEXT_IDENTIFIER)
 
     override val installationIdentifier by lazy {
         // Further reading: https://developer.android.com/training/articles/user-data-ids.html
         // if persisted UUID not present then generate and persist a new one. Memoize it in memory.
-        (storage.get(identifierKey) ?: (
+        (storage[identifierKey] ?: (
             (getAndClearSdk2IdentifierIfPresent() ?: UUID.randomUUID().toString()).apply {
-                storage.set(identifierKey, this)
+                storage[identifierKey] = this
             }
         )).apply {
             log.v("Device Rover installation identifier: $this")
@@ -44,17 +44,16 @@ class DeviceIdentification(
     // On many manufacturers' Android devices, the set device name manifests as the Bluetooth name,
     // but not as the device hostname.  So, we'll ignore the device hostname and use the Bluetooth
     // name, if available.
-    override val deviceName: String?
+    override var deviceName: String?
         get() {
-            return if (Build.VERSION.SDK_INT < 31) {
-                return Settings.Secure.getString(
-                    applicationContext.contentResolver,
-                    "bluetooth_name"
-                )
-            } else {
-                // TODO: fallback to getting hostname or similar.
-                null
+            return (storage[deviceNameKey] ?: "Phone").apply {
+                log.v("Device name: $this")
             }
+        }
+
+        set(value) {
+            storage[deviceNameKey] = value
+            log.v("Device name set to: $value")
         }
 
     private fun getAndClearSdk2IdentifierIfPresent(): String? {

--- a/debug/src/main/kotlin/io/rover/campaigns/debug/DebugPreferences.kt
+++ b/debug/src/main/kotlin/io/rover/campaigns/debug/DebugPreferences.kt
@@ -3,6 +3,7 @@ package io.rover.campaigns.debug
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
 import androidx.preference.EditTextPreference
+import androidx.preference.Preference
 import androidx.preference.PreferenceManager
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
@@ -33,10 +34,18 @@ class DebugPreferences(
                 EditTextPreference(
                     preferenceManager.context
                 ).apply {
-                    isSelectable = false
+                    isSelectable = true
                     isPersistent = false
                     title = context.getText(R.string.debug_settings_device_name)
                     summary = deviceIdentification.deviceName
+                    key = "edit_device_name"
+                    dialogTitle = context.getText(R.string.debug_settings_set_device_name)
+                    dialogMessage = context.getText(R.string.debug_settings_device_name_description)
+                    onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
+                        deviceIdentification.deviceName = newValue as String
+                        summary = newValue
+                        true
+                    }
                 }
             )
             addPreference(

--- a/debug/src/main/res/values/strings.xml
+++ b/debug/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="debug_settings_test_device">Test Device</string>
     <string name="debug_settings_device_name">Device Name</string>
     <string name="debug_settings_device_id">Device ID</string>
+    <string name="debug_settings_set_device_name">Set Device Name</string>
+    <string name="debug_settings_device_name_description">Set the device name to be used for testing</string>
 </resources>


### PR DESCRIPTION
Make the device property editable, and allow it to be set by the user when testing.

Resolves https://github.com/judoapp/rover-issues/issues/26